### PR TITLE
Adding userData

### DIFF
--- a/coxedge/apiclient/models.go
+++ b/coxedge/apiclient/models.go
@@ -152,6 +152,7 @@ type Workload struct {
 	Deployments                 []WorkloadAutoscaleDeployment `json:"deployments,omitempty"`
 	EnvironmentVariables        []WorkloadEnvironmentVariable `json:"environmentVariables,omitempty"`
 	FirstBootSshKey             string                        `json:"firstBootSshKey,omitempty"`
+	UserData                    string                        `json:"userData,omitempty"`
 	Id                          string                        `json:"id,omitempty"`
 	Image                       string                        `json:"image,omitempty"`
 	IsRemoteManagementEnabled   bool                          `json:"isRemoteManagementEnabled,omitempty"`

--- a/coxedge/apiclient/workloads.go
+++ b/coxedge/apiclient/workloads.go
@@ -28,6 +28,7 @@ type WorkloadCreateRequest struct {
 	ContainerUsername             string                        `json:"containerUsername,omitempty"`
 	EnvironmentVariables          []WorkloadEnvironmentVariable `json:"environmentVariables,omitempty"`
 	FirstBootSSHKey               string                        `json:"firstBootSshKey,omitempty"`
+	UserData                      string                        `json:"userData,omitempty"`
 	PersistentStorage             []WorkloadPersistentStorage   `json:"persistentStorages,omitempty"`
 	Ports                         []WorkloadPort                `json:"ports,omitempty"`
 	SecretEnvironmentVariables    []WorkloadEnvironmentVariable `json:"secretEnvironmentVariables,omitempty"`

--- a/coxedge/resource_workload.go
+++ b/coxedge/resource_workload.go
@@ -172,6 +172,7 @@ func convertResourceDataToWorkloadCreateAPIObject(d *schema.ResourceData) apicli
 		Type:                d.Get("type").(string),
 		AddAnyCastIpAddress: d.Get("add_anycast_ip_address").(bool),
 		FirstBootSSHKey:     d.Get("first_boot_ssh_key").(string),
+		UserData:            d.Get("user_data").(string),
 		ContainerEmail:      d.Get("container_email").(string),
 		ContainerServer:     d.Get("container_server").(string),
 		ContainerUsername:   d.Get("container_username").(string),
@@ -256,6 +257,7 @@ func convertWorkloadAPIObjectToResourceData(d *schema.ResourceData, workload *ap
 	d.Set("container_username", workload.ContainerUsername)
 	d.Set("container_server", workload.ContainerServer)
 	d.Set("first_boot_ssh_key", workload.FirstBootSshKey)
+	d.Set("user_data", workload.UserData)
 	//Now the list structures
 	deployments := make([]map[string]interface{}, len(workload.Deployments), len(workload.Deployments))
 	for i, deployment := range workload.Deployments {

--- a/coxedge/tf_schemas.go
+++ b/coxedge/tf_schemas.go
@@ -7,10 +7,11 @@ package coxedge
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"strconv"
 )
 
 func getOrganizationSetSchema() map[string]*schema.Schema {
@@ -481,6 +482,11 @@ func getWorkloadSchema() map[string]*schema.Schema {
 			Optional: true,
 		},
 		"first_boot_ssh_key": {
+			Type:     schema.TypeString,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Optional: true,
+		},
+		"user_data": {
 			Type:     schema.TypeString,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Optional: true,

--- a/tests/scripts/workload-vm-optional/main.tf
+++ b/tests/scripts/workload-vm-optional/main.tf
@@ -31,6 +31,11 @@ resource "coxedge_workload" "test" {
     size = 1
   }
   first_boot_ssh_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDcYr9OnzsDfYVW2I1kX/iYJ0mPG490bI5mbxbOAKPLMuWLguxRohX804j1XbwZJ+Sna+9rSfxaYA8vgd1MoYX10l9cnMLx/MMbYp4ZquauN4pGY3WoDeCqsTss3VUMW+7RFBILpU3SJTlDV02FI36D3IXb4A8XymCyU3KC99XXTfTQsuKC+WFRMsTWtklrasqCVd5yEG90i/aJc6A3TZGOYgPFNEeVYvNDaJmIkb3y4FfShoBIMgZRt0ay7SvWZUvyfvyNmK5W9ePdhZZ58R+7tQNmCzjQ4v0suWRuGJ/XL3+03w3HEsDdQx+noL+R+qAjoNFwc0spBBhJK+Q4ADqr nothing@gmail.com"
+  user_data = <<EOF
+#cloud-config
+runcmd:
+  - echo "Hello World" > /lib/data/newFolder/hello.txt
+EOF
   specs = "SP-1"
   deployment {
     name = "testvm"


### PR DESCRIPTION
This PR adds the field user_data which is an undocumented API spec. This field is required in order to pass a cloud-init to a VM.